### PR TITLE
wp_rewrite_rules()で取得したリライトルールに、否定先読み(?!regex)の正規表現が含まれていた場合に発生するデリミタ…

### DIFF
--- a/modules/functions.php
+++ b/modules/functions.php
@@ -366,7 +366,7 @@ function sga_ranking_url_to_postid( $url ) {
 				$request_match = $url . '/' . $request;
 			}
 
-			if ( preg_match( "!^$match!", $request_match, $matches ) ) {
+			if ( preg_match( "#^$match#", $request_match, $matches ) ) {
 				// Got a match.
 				// Trim the query of everything up to the '?'.
 				$query = preg_replace( "!^.+\?!", '', $query );


### PR DESCRIPTION
リライトルールの正規表現マッチはWordPress本体 wp-includes/rewrite.php で使われている # デリミタを使用する形にしてみました。

https://github.com/WordPress/WordPress/blob/master/wp-includes/rewrite.php#L608